### PR TITLE
Own 'com.dropbox.Client' on the session bus for the first instance

### DIFF
--- a/src/eos-dropbox-app
+++ b/src/eos-dropbox-app
@@ -102,12 +102,17 @@ def get_dropbox_directory():
 
 class DropboxLauncher():
 
+    def __init__(self):
+        self._mainloop = GLib.MainLoop()
+
     def run(self):
         self._launch_dropbox_daemon()
         self._open_dropbox_directory()
+        self._mainloop.run()
 
     def _exitOnError(self, message):
         logging.error(message)
+        self._mainloop.quit()
         sys.exit(1)
 
     def _open_dropbox_directory(self):
@@ -132,12 +137,42 @@ class DropboxLauncher():
                                            None)
 
             logging.info("Opening Dropbox directory at {}...".format(uri))
-            proxy.OpenURI('(ssa{sv})',
-                          '',                          # Parent window ID
-                          uri,                         # URI
-                          GLib.Variant('a{sv}', None)) # Options
+            handle = proxy.OpenURI('(ssa{sv})',
+                                   '',                          # Parent window ID
+                                   uri,                         # URI
+                                   GLib.Variant('a{sv}', None)) # Options
+
+            # The OpenURI method returns a handle to a 'request object', which stays
+            # alive for the duration of the user interaction related to the method call,
+            # so we connect to its Response signal to know when it's all over.
+            bus.signal_subscribe('org.freedesktop.portal.Desktop',
+                                 'org.freedesktop.portal.Request',
+                                 'Response',
+                                 handle,
+                                 None,
+                                 Gio.DBusSignalFlags.NO_MATCH_RULE,
+                                 self._responseReceived)
+
         except GLib.Error as e:
             self._exitOnError("Could not launch the OpenURI portal for {}: {}".format(uri, e.message))
+
+    def _responseReceived(self, connection, sender, path, interface, signal, params):
+        # Format string for the Response signal is 'ua{sv}', but we are
+        # only interested in the first parameter here (response code).
+        #
+        # Response code values:
+        #  0: Success
+        #  1: User cancelled action (e.g. Canceled the App Chooser dialog).
+        #  2: Error
+        (response_code, results) = params.unpack()
+        if response_code == 0:
+            logging.info('OpenURI portal: success!')
+        elif response_code == 1:
+            logging.info('OpenURI portal: cancelled by the user')
+        elif response_code == 2:
+            logging.warning('OpenURI portal: An error happened')
+
+        self._mainloop.quit()
 
     def _launch_dropbox_daemon(self):
         logging.info("Launching Dropbox's daemon at {}...".format(DROPBOX_LAUNCHER))

--- a/src/eos-dropbox-app
+++ b/src/eos-dropbox-app
@@ -119,23 +119,24 @@ def open_dropbox_directory():
     elif not os.path.isdir(directory):
         exitOnError("{} is not a directory!".format(directory))
 
-    bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
-    proxy = Gio.DBusProxy.new_sync(bus, Gio.DBusProxyFlags.NONE,
-                                   None,
-                                   'org.freedesktop.portal.Desktop',
-                                   '/org/freedesktop/portal/desktop',
-                                   'org.freedesktop.portal.OpenURI',
-                                   None)
-
     uri = "file://{}".format(os.path.expanduser(directory))
 
-    logging.info("Opening Dropbox directory at {}...".format(uri))
-    result = proxy.OpenURI('(ssa{sv})',
-                           '',                          # Parent window ID
-                           uri,                         # URI
-                           GLib.Variant('a{sv}', None)) # Options
-    if result is None:
-        logging.warning("Could not launch the OpenURI portal for {}".format())
+    try:
+        bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+        proxy = Gio.DBusProxy.new_sync(bus, Gio.DBusProxyFlags.NONE,
+                                       None,
+                                       'org.freedesktop.portal.Desktop',
+                                       '/org/freedesktop/portal/desktop',
+                                       'org.freedesktop.portal.OpenURI',
+                                       None)
+
+        logging.info("Opening Dropbox directory at {}...".format(uri))
+        proxy.OpenURI('(ssa{sv})',
+                      '',                          # Parent window ID
+                      uri,                         # URI
+                      GLib.Variant('a{sv}', None)) # Options
+    except GLib.Error as e:
+        exitOnError("Could not launch the OpenURI portal for {}: {}".format(uri, e.message))
 
 
 if __name__ == '__main__':

--- a/src/eos-dropbox-app
+++ b/src/eos-dropbox-app
@@ -32,9 +32,9 @@ from gi.repository import Gio
 from gi.repository import GLib
 
 
-DROPBOX_CONFIG = "~/.dropbox/info.json"
-DROPBOX_LAUNCHER  = "/app/extra/.dropbox-dist/dropboxd"
-DROPBOX_DEFAULT_DIR  = "~/Dropbox"
+DROPBOX_CONFIG = '~/.dropbox/info.json'
+DROPBOX_LAUNCHER  = '/app/extra/.dropbox-dist/dropboxd'
+DROPBOX_DEFAULT_DIR  = '~/Dropbox'
 
 
 def get_default_dropbox_directory():
@@ -60,11 +60,11 @@ def get_dropbox_directory():
 
     logging.info("Looking for Dropbox configuration...")
     if not os.path.exists(config_path):
-        logging.info('Dropbox configuration not found')
+        logging.info("Dropbox configuration not found")
         return None
 
     with open(config_path, 'r') as config:
-        logging.info('Found Dropbox configuration at {}'.format(config_path))
+        logging.info("Found Dropbox configuration at {}".format(config_path))
 
         path = None
         account_type = None
@@ -73,7 +73,7 @@ def get_dropbox_directory():
         try:
             json_data = json.loads(data)
         except ValueError as e:
-            logging.warning('Error loading JSON data from {}: {}'.format(DROPBOX_CONFIG, str(e)))
+            logging.warning("Error loading JSON data from {}: {}".format(DROPBOX_CONFIG, str(e)))
 
         # Search for valid user configuration (containing 'path')
         # and for the type of account (for logging purposes)
@@ -86,15 +86,15 @@ def get_dropbox_directory():
         if path:
             try:
                 dropbox_dir = os.path.expanduser(path)
-                logging.info('Found configured Dropbox directory at {} ({} account)'
+                logging.info("Found configured Dropbox directory at {} ({} account)"
                              .format(dropbox_dir, account_type))
             except KeyError:
-                logging.warning('Could not find Dropbox directory in user\'s configuration')
+                logging.warning("Could not find Dropbox directory in user's configuration")
         else:
-            logging.warning('Could not find user\'s configuration in Dropbox\'s configuration file')
+            logging.warning("Could not find user's configuration in Dropbox's configuration file")
 
     if not dropbox_dir:
-        logging.warning('Could not find a valid Dropbox directory in the configuration. Falling back to defaults...')
+        logging.warning("Could not find a valid Dropbox directory in the configuration. Falling back to defaults...")
         dropbox_dir = get_default_dropbox_directory()
 
     return dropbox_dir
@@ -108,7 +108,7 @@ class DropboxLauncher():
 
     def run(self):
         Gio.bus_own_name(Gio.BusType.SESSION,
-                         "com.dropbox.Client",
+                         'com.dropbox.Client',
                          Gio.BusNameOwnerFlags.NONE,
                          None, # Bus Acquired callback
                          self._name_acquired,
@@ -135,12 +135,12 @@ class DropboxLauncher():
         logging.info("Attempting to open Dropbox directory at {}...".format(directory))
 
         if not directory:
-            logging.warning('User has not configured Dropbox yet')
+            logging.warning("User has not configured Dropbox yet")
             return
         elif not os.path.isdir(directory):
             self._exitOnError("{} is not a directory!".format(directory))
 
-        uri = "file://{}".format(os.path.expanduser(directory))
+        uri = 'file://{}'.format(os.path.expanduser(directory))
 
         try:
             bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
@@ -181,16 +181,16 @@ class DropboxLauncher():
         #  2: Error
         (response_code, results) = params.unpack()
         if response_code == 0:
-            logging.info('OpenURI portal: success!')
+            logging.info("OpenURI portal: success!")
         elif response_code == 1:
-            logging.info('OpenURI portal: cancelled by the user')
+            logging.info("OpenURI portal: cancelled by the user")
         elif response_code == 2:
-            logging.warning('OpenURI portal: An error happened')
+            logging.warning("OpenURI portal: An error happened")
 
         if self._already_running:
             # Dropbox launcher already running as a different process,
             # so we can quit here after having handled the URI request
-            logging.info('Not the main launcher instance. Exiting')
+            logging.info("Not the main launcher instance. Exiting")
             self._mainloop.quit()
 
     def _launch_dropbox_daemon(self):
@@ -200,7 +200,7 @@ class DropboxLauncher():
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument("--debug", dest="debug", action="store_true")
+    parser.add_argument('--debug', dest='debug', action='store_true')
 
     parsed_args = parser.parse_args()
     if parsed_args.debug:

--- a/src/eos-dropbox-app
+++ b/src/eos-dropbox-app
@@ -104,11 +104,26 @@ class DropboxLauncher():
 
     def __init__(self):
         self._mainloop = GLib.MainLoop()
+        self._already_running = False
 
     def run(self):
+        Gio.bus_own_name(Gio.BusType.SESSION,
+                         "com.dropbox.Client",
+                         Gio.BusNameOwnerFlags.NONE,
+                         None, # Bus Acquired callback
+                         self._name_acquired,
+                         self._name_lost)
+        self._mainloop.run()
+
+    def _name_acquired(self, *args):
+        logging.info("No instance of dropbox already running")
         self._launch_dropbox_daemon()
         self._open_dropbox_directory()
-        self._mainloop.run()
+
+    def _name_lost(self, *args):
+        logging.info("Another instance of dropbox is already running")
+        self._already_running = True
+        self._open_dropbox_directory()
 
     def _exitOnError(self, message):
         logging.error(message)
@@ -172,7 +187,11 @@ class DropboxLauncher():
         elif response_code == 2:
             logging.warning('OpenURI portal: An error happened')
 
-        self._mainloop.quit()
+        if self._already_running:
+            # Dropbox launcher already running as a different process,
+            # so we can quit here after having handled the URI request
+            logging.info('Not the main launcher instance. Exiting')
+            self._mainloop.quit()
 
     def _launch_dropbox_daemon(self):
         logging.info("Launching Dropbox's daemon at {}...".format(DROPBOX_LAUNCHER))

--- a/src/eos-dropbox-app
+++ b/src/eos-dropbox-app
@@ -41,32 +41,61 @@ def launch_dropbox_daemon():
     subprocess.Popen([DROPBOX_LAUNCHER])
 
 
+def get_default_dropbox_directory():
+    default_dir = os.path.expanduser(DROPBOX_DEFAULT_DIR)
+
+    if os.path.isdir(default_dir):
+        return default_dir
+
+    # If no Dropbox folder found, that means that the user has not
+    # configured Dropbox yet, so there's not much we can do now
+    return None
+
+
 def get_dropbox_directory():
-    dropbox_dir = os.path.expanduser(DROPBOX_DEFAULT_DIR)
+    dropbox_dir = None
+    config_path = os.path.expanduser(DROPBOX_CONFIG)
 
-    logging.info("Looking for the configured Dropbox directory...")
-    with open(os.path.expanduser(DROPBOX_CONFIG), 'r') as config:
+    logging.info("Looking for Dropbox configuration...")
+    if not os.path.exists(config_path):
+        logging.info('Dropbox configuration not found')
+        return None
+
+    with open(config_path, 'r') as config:
+        logging.info('Found Dropbox configuration at {}'.format(config_path))
+
         data = config.read()
-
         try:
             json_data = json.loads(data)
-        except json.JSONDecodeError as e:
+            try:
+                dropbox_dir = os.path.expanduser(json_data['personal']['path'])
+                logging.info('Found configured Dropbox directory at {}'.format(dropbox_dir))
+            except KeyError:
+                logging.warning('Could not find Dropbox directory in user\'s configuration')
+
+        except ValueError as e:
             logging.warning('Error loading JSON data from {}: {}'.format(DROPBOX_CONFIG, str(e)))
 
-        try:
-            dropbox_dir = os.path.expanduser(json_data['personal']['path'])
-        except KeyError:
-            logging.warning('Could not find Dropbox directory')
+    if not dropbox_dir:
+        logging.warning('Could not find a valid Dropbox directory in the configuration. Falling back to defaults...')
+        dropbox_dir = get_default_dropbox_directory()
 
-    logging.info("Using Dropbox directory: {}".format(dropbox_dir))
     return dropbox_dir
+
+
+def exitOnError(message):
+    logging.error(message)
+    sys.exit(1)
 
 
 def open_dropbox_directory():
     directory = get_dropbox_directory()
-    if not os.path.isdir(directory):
-        logging.warning("{} is not a directory".format(directory))
+
+    if not directory:
+        logging.warning('User has not configured Dropbox yet')
         return
+    elif not os.path.isdir(directory):
+        exitOnError("{} is not a directory!".format(directory))
 
     bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
     proxy = Gio.DBusProxy.new_sync(bus, Gio.DBusProxyFlags.NONE,

--- a/src/eos-dropbox-app
+++ b/src/eos-dropbox-app
@@ -127,7 +127,7 @@ def open_dropbox_directory():
                                    'org.freedesktop.portal.OpenURI',
                                    None)
 
-    uri = "file://{}".format(os.path.expanduser(DROPBOX_DEFAULT_DIR))
+    uri = "file://{}".format(os.path.expanduser(directory))
 
     logging.info("Opening Dropbox directory at {}...".format(uri))
     result = proxy.OpenURI('(ssa{sv})',

--- a/src/eos-dropbox-app
+++ b/src/eos-dropbox-app
@@ -42,7 +42,7 @@ def launch_dropbox_daemon():
 
 
 def get_dropbox_directory():
-    config_path = os.path.expanduser(DROPBOX_DEFAULT_DIR)
+    dropbox_dir = os.path.expanduser(DROPBOX_DEFAULT_DIR)
 
     logging.info("Looking for the configured Dropbox directory...")
     with open(os.path.expanduser(DROPBOX_CONFIG), 'r') as config:
@@ -54,12 +54,12 @@ def get_dropbox_directory():
             logging.warning('Error loading JSON data from {}: {}'.format(DROPBOX_CONFIG, str(e)))
 
         try:
-            config_path = os.path.expanduser(json_data['personal']['path'])
+            dropbox_dir = os.path.expanduser(json_data['personal']['path'])
         except KeyError:
             logging.warning('Could not find Dropbox directory')
 
-    logging.info("Using Dropbox directory: {}".format(config_path))
-    return config_path
+    logging.info("Using Dropbox directory: {}".format(dropbox_dir))
+    return dropbox_dir
 
 
 def open_dropbox_directory():

--- a/src/eos-dropbox-app
+++ b/src/eos-dropbox-app
@@ -21,6 +21,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import argparse
+import glob
 import json
 import logging
 import os
@@ -46,6 +47,12 @@ def get_default_dropbox_directory():
 
     if os.path.isdir(default_dir):
         return default_dir
+
+    # No 'Dropbox' directory found, our last attempt will be to look for a Dropbox
+    # team folder, used in 'business' accounts (e.g. 'Dropbox (Endless Team)')
+    team_dir = glob.glob(default_dir + ' (*)')
+    if team_dir:
+        return team_dir[0]
 
     # If no Dropbox folder found, that means that the user has not
     # configured Dropbox yet, so there's not much we can do now

--- a/src/eos-dropbox-app
+++ b/src/eos-dropbox-app
@@ -37,11 +37,6 @@ DROPBOX_LAUNCHER  = "/app/extra/.dropbox-dist/dropboxd"
 DROPBOX_DEFAULT_DIR  = "~/Dropbox"
 
 
-def launch_dropbox_daemon():
-    logging.info("Launching Dropbox's daemon at {}...".format(DROPBOX_LAUNCHER))
-    subprocess.Popen([DROPBOX_LAUNCHER])
-
-
 def get_default_dropbox_directory():
     default_dir = os.path.expanduser(DROPBOX_DEFAULT_DIR)
 
@@ -105,38 +100,48 @@ def get_dropbox_directory():
     return dropbox_dir
 
 
-def exitOnError(message):
-    logging.error(message)
-    sys.exit(1)
+class DropboxLauncher():
 
+    def run(self):
+        self._launch_dropbox_daemon()
+        self._open_dropbox_directory()
 
-def open_dropbox_directory():
-    directory = get_dropbox_directory()
+    def _exitOnError(self, message):
+        logging.error(message)
+        sys.exit(1)
 
-    if not directory:
-        logging.warning('User has not configured Dropbox yet')
-        return
-    elif not os.path.isdir(directory):
-        exitOnError("{} is not a directory!".format(directory))
+    def _open_dropbox_directory(self):
+        directory = get_dropbox_directory()
+        logging.info("Attempting to open Dropbox directory at {}...".format(directory))
 
-    uri = "file://{}".format(os.path.expanduser(directory))
+        if not directory:
+            logging.warning('User has not configured Dropbox yet')
+            return
+        elif not os.path.isdir(directory):
+            self._exitOnError("{} is not a directory!".format(directory))
 
-    try:
-        bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
-        proxy = Gio.DBusProxy.new_sync(bus, Gio.DBusProxyFlags.NONE,
-                                       None,
-                                       'org.freedesktop.portal.Desktop',
-                                       '/org/freedesktop/portal/desktop',
-                                       'org.freedesktop.portal.OpenURI',
-                                       None)
+        uri = "file://{}".format(os.path.expanduser(directory))
 
-        logging.info("Opening Dropbox directory at {}...".format(uri))
-        proxy.OpenURI('(ssa{sv})',
-                      '',                          # Parent window ID
-                      uri,                         # URI
-                      GLib.Variant('a{sv}', None)) # Options
-    except GLib.Error as e:
-        exitOnError("Could not launch the OpenURI portal for {}: {}".format(uri, e.message))
+        try:
+            bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+            proxy = Gio.DBusProxy.new_sync(bus, Gio.DBusProxyFlags.NONE,
+                                           None,
+                                           'org.freedesktop.portal.Desktop',
+                                           '/org/freedesktop/portal/desktop',
+                                           'org.freedesktop.portal.OpenURI',
+                                           None)
+
+            logging.info("Opening Dropbox directory at {}...".format(uri))
+            proxy.OpenURI('(ssa{sv})',
+                          '',                          # Parent window ID
+                          uri,                         # URI
+                          GLib.Variant('a{sv}', None)) # Options
+        except GLib.Error as e:
+            self._exitOnError("Could not launch the OpenURI portal for {}: {}".format(uri, e.message))
+
+    def _launch_dropbox_daemon(self):
+        logging.info("Launching Dropbox's daemon at {}...".format(DROPBOX_LAUNCHER))
+        subprocess.Popen([DROPBOX_LAUNCHER])
 
 
 if __name__ == '__main__':
@@ -147,14 +152,4 @@ if __name__ == '__main__':
     if parsed_args.debug:
         logging.basicConfig(level=logging.INFO)
 
-    # XXX: This launches a new daemon instance each time which is not ideal
-    # and should be fixed. See https://phabricator.endlessm.com/T15115.
-    #
-    # Simple solutions like checking the ~/.dropbox/dropbox.pid are unfortunately
-    # not possible since this runs inside the Flatpak sandbox but a way to detect
-    # whether this is already running should be implemented in the future.
-    logging.info("Attempting to run eos-dropbox-app launcher...")
-    launch_dropbox_daemon()
-
-    logging.info("Attempting to open Dropbox directory...")
-    open_dropbox_directory()
+    DropboxLauncher().run()

--- a/src/eos-dropbox-app
+++ b/src/eos-dropbox-app
@@ -64,17 +64,32 @@ def get_dropbox_directory():
     with open(config_path, 'r') as config:
         logging.info('Found Dropbox configuration at {}'.format(config_path))
 
+        path = None
+        account_type = None
+
         data = config.read()
         try:
             json_data = json.loads(data)
-            try:
-                dropbox_dir = os.path.expanduser(json_data['personal']['path'])
-                logging.info('Found configured Dropbox directory at {}'.format(dropbox_dir))
-            except KeyError:
-                logging.warning('Could not find Dropbox directory in user\'s configuration')
-
         except ValueError as e:
             logging.warning('Error loading JSON data from {}: {}'.format(DROPBOX_CONFIG, str(e)))
+
+        # Search for valid user configuration (containing 'path')
+        # and for the type of account (for logging purposes)
+        for type_name in json_data:
+            if 'path' in json_data[type_name]:
+                path = json_data[type_name]['path']
+                account_type = type_name
+                break
+
+        if path:
+            try:
+                dropbox_dir = os.path.expanduser(path)
+                logging.info('Found configured Dropbox directory at {} ({} account)'
+                             .format(dropbox_dir, account_type))
+            except KeyError:
+                logging.warning('Could not find Dropbox directory in user\'s configuration')
+        else:
+            logging.warning('Could not find user\'s configuration in Dropbox\'s configuration file')
 
     if not dropbox_dir:
         logging.warning('Could not find a valid Dropbox directory in the configuration. Falling back to defaults...')


### PR DESCRIPTION
It is not possible to check from a sandbox whether there's another
'dropbox' process running in the system since we can't check PIDs
outside of the sandbox, and even if we checked the dropbox.pid file
that would refer to a PID inside a different sandbox.

For this reason, we better own a name on the session bus, which is
something we can easily check from any other instance of this flatpak
application, and use the 'name_acquired' and 'name_lost' to decide
whether we only want to open the Dropbox directory or also to spawn
a new running instance of the 'dropbox' daemon.

https://phabricator.endlessm.com/T15115