### PR TITLE
Always launch the daemon if the Dropbox folder is not found

### DIFF
--- a/src/eos-dropbox-app
+++ b/src/eos-dropbox-app
@@ -121,8 +121,13 @@ class DropboxLauncher():
         self._open_dropbox_directory()
 
     def _name_lost(self, *args):
-        logging.info("Another instance of dropbox is already running")
-        self._already_running = True
+        if not get_dropbox_directory():
+            logging.info("Another instance of dropbox is already running but no "
+                         "Dropbox folder was found; launching the daemon again")
+            self._launch_dropbox_daemon()
+        else:
+            logging.info("Another instance of dropbox is already running")
+            self._already_running = True
         self._open_dropbox_directory()
 
     def _exitOnError(self, message):


### PR DESCRIPTION
When the Dropbox folder is not found we need to launch the daemon, even
if it is already running. The reason is that Dropbox has changed and now
it opens the browser for the user authentication, instead of its own
application. So, if the user just closes the browser, or an error
occurred and it couldn't be opened, we're left in a state where the
daemon is running but Dropbox has not been configured. Thus, if we do
not run the daemon again, the user will not be able to log in again.

https://phabricator.endlessm.com/T16226