### PR TITLE
Set monitors to better manage when to open the Dropbox dir

### DIFF
--- a/src/eos-dropbox-app
+++ b/src/eos-dropbox-app
@@ -105,6 +105,8 @@ class DropboxLauncher():
     def __init__(self):
         self._mainloop = GLib.MainLoop()
         self._already_running = False
+        self._config_monitor = None
+        self._dir_monitor = None
 
     def run(self):
         Gio.bus_own_name(Gio.BusType.SESSION,
@@ -117,18 +119,17 @@ class DropboxLauncher():
 
     def _name_acquired(self, *args):
         logging.info("No instance of dropbox already running")
-        self._launch_dropbox_daemon()
-        self._open_dropbox_directory()
+        self._launch_dropbox()
 
     def _name_lost(self, *args):
         if not get_dropbox_directory():
             logging.info("Another instance of dropbox is already running but no "
                          "Dropbox folder was found; launching the daemon again")
-            self._launch_dropbox_daemon()
+            self._launch_dropbox()
         else:
             logging.info("Another instance of dropbox is already running")
             self._already_running = True
-        self._open_dropbox_directory()
+            self._open_dropbox_directory()
 
     def _exitOnError(self, message):
         logging.error(message)
@@ -198,10 +199,50 @@ class DropboxLauncher():
             logging.info("Not the main launcher instance. Exiting")
             self._mainloop.quit()
 
+    def _launch_dropbox(self):
+        self._launch_dropbox_daemon()
+        self._setup_config_monitor()
+
+    def _setup_config_monitor(self):
+        config = Gio.File.new_for_path(os.path.expanduser(os.path.expanduser(DROPBOX_CONFIG)))
+        self._config_monitor = config.monitor(Gio.FileMonitorFlags.NONE)
+        self._config_monitor.connect('changed', self._on_config_changed)
+
     def _launch_dropbox_daemon(self):
         logging.info("Launching Dropbox's daemon at {}...".format(DROPBOX_LAUNCHER))
         subprocess.Popen([DROPBOX_LAUNCHER])
 
+    def _on_config_changed(self, monitor, file_obj, other_file, event_type):
+        logging.info("Config file monitor {}: {}".format(file_obj.get_path(), event_type))
+        if event_type != Gio.FileMonitorEvent.CHANGES_DONE_HINT:
+            if event_type == Gio.FileMonitorEvent.DELETED and self._dir_monitor:
+                self._dir_monitor.cancel()
+            return
+        self._config_monitor.cancel()
+        if os.path.exists(file_obj.get_path()):
+            logging.info("Configuration for Dropbox created; opening folder when created...")
+            self._open_dropbox_when_created()
+
+    def _open_dropbox_when_created(self):
+        dropbox_dir = get_dropbox_directory()
+        if dropbox_dir is None:
+            logging.warning("No Dropbox folder configured yet. Cannot open or monitor it!")
+            return
+        if os.path.exists(dropbox_dir):
+            self._open_dropbox_directory()
+            return
+        logging.info("Setting up monitor for folder {}...".format(dropbox_dir))
+        dir_obj = Gio.File.new_for_path(dropbox_dir)
+        self._dir_monitor = dir_obj.monitor(Gio.FileMonitorFlags.NONE)
+        self._dir_monitor.connect('changed', self._on_dir_changed)
+
+    def _on_dir_changed(self, monitor, file_obj, other_file, event_type):
+        logging.info("Dropbox dir monitor {}: {}".format(file_obj.get_path(), event_type))
+        if event_type != Gio.FileMonitorEvent.CREATED:
+            return
+        logging.info("Dropbox folder created; opening now...")
+        self._open_dropbox_directory()
+        self._dir_monitor.cancel()
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/src/eos-dropbox-app
+++ b/src/eos-dropbox-app
@@ -109,6 +109,7 @@ class DropboxLauncher():
         self._dir_monitor = None
         self._bus_owner_id = 0
         self._quit_if_name_lost = False
+        self._daemon = None
 
     def run(self):
         self._try_own_bus_name()
@@ -142,7 +143,7 @@ class DropboxLauncher():
     def _name_lost(self, *args):
         if self._quit_if_name_lost:
             logging.info("Lost the DBus name ownership; quitting...")
-            self._mainloop.quit()
+            self._quit()
             return
 
         if not get_dropbox_directory():
@@ -152,12 +153,17 @@ class DropboxLauncher():
         else:
             logging.info("Another instance of dropbox is already running")
             self._already_running = True
-            self._open_dropbox_directory()
+            self._open_dropbox_when_created()
 
     def _exitOnError(self, message):
         logging.error(message)
+        self._quit(1)
+
+    def _quit(self, retcode=0):
+        if self._daemon:
+            self._daemon.terminate()
         self._mainloop.quit()
-        sys.exit(1)
+        sys.exit(retcode)
 
     def _open_dropbox_directory(self):
         directory = get_dropbox_directory()
@@ -220,7 +226,7 @@ class DropboxLauncher():
             # Dropbox launcher already running as a different process,
             # so we can quit here after having handled the URI request
             logging.info("Not the main launcher instance. Exiting")
-            self._mainloop.quit()
+            self._quit()
 
     def _launch_dropbox(self):
         self._launch_dropbox_daemon()
@@ -233,7 +239,10 @@ class DropboxLauncher():
 
     def _launch_dropbox_daemon(self):
         logging.info("Launching Dropbox's daemon at {}...".format(DROPBOX_LAUNCHER))
-        subprocess.Popen([DROPBOX_LAUNCHER])
+        # Safety check just in case this is called more than once
+        if self._daemon:
+            self._daemon.terminate()
+        self._daemon = subprocess.Popen([DROPBOX_LAUNCHER])
 
     def _on_config_changed(self, monitor, file_obj, other_file, event_type):
         logging.info("Config file monitor {}: {}".format(file_obj.get_path(), event_type))

--- a/src/eos-dropbox-app
+++ b/src/eos-dropbox-app
@@ -107,25 +107,48 @@ class DropboxLauncher():
         self._already_running = False
         self._config_monitor = None
         self._dir_monitor = None
+        self._bus_owner_id = 0
+        self._quit_if_name_lost = False
 
     def run(self):
-        Gio.bus_own_name(Gio.BusType.SESSION,
-                         'com.dropbox.Client',
-                         Gio.BusNameOwnerFlags.NONE,
-                         None, # Bus Acquired callback
-                         self._name_acquired,
-                         self._name_lost)
+        self._try_own_bus_name()
         self._mainloop.run()
+
+    def _try_own_bus_name(self, replace=False):
+        if self._bus_owner_id != 0:
+            Gio.bus_unown_name(self._bus_owner_id)
+
+        flags = Gio.BusNameOwnerFlags.ALLOW_REPLACEMENT
+        if replace:
+            flags |= Gio.BusNameOwnerFlags.REPLACE
+            self._quit_if_name_lost = True
+            logging.info("Trying to own the dropbox dbus name (this time "
+                         "replacing existing ones)...")
+        else:
+            logging.info("Trying to own the dropbox dbus name...")
+
+        self._bus_owner_id = Gio.bus_own_name(Gio.BusType.SESSION,
+                                              'com.dropbox.Client',
+                                              flags,
+                                              None, # Bus Acquired callback
+                                              self._name_acquired,
+                                              self._name_lost)
 
     def _name_acquired(self, *args):
         logging.info("No instance of dropbox already running")
+        self._quit_if_name_lost = True
         self._launch_dropbox()
 
     def _name_lost(self, *args):
+        if self._quit_if_name_lost:
+            logging.info("Lost the DBus name ownership; quitting...")
+            self._mainloop.quit()
+            return
+
         if not get_dropbox_directory():
             logging.info("Another instance of dropbox is already running but no "
                          "Dropbox folder was found; launching the daemon again")
-            self._launch_dropbox()
+            self._try_own_bus_name(replace=True)
         else:
             logging.info("Another instance of dropbox is already running")
             self._already_running = True


### PR DESCRIPTION
The configured Dropbox directory may not be immediately available when
the daemon is started, thus readily opening at that moment may not be
very effective.

This patch sets up a monitor for the configuration file and, upon
detecting changes to it, starts watching the configured directory,
opening it only when it is effectively created.
This also allows for the folder to be reopened when: e.g. the daemon is
already running but the user deletes the Dropbox folder; in this case a
new dialog will as the user whether to relink the folder, in which case,
the folder is again opened after its creation.

https://phabricator.endlessm.com/T16271